### PR TITLE
docs: sync picture and text in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Repo for code that can run outside the enclave, such as distance calculations, manipulation of shapefiles, aggregated maps, etc.
 
 ### Contribution Workflow:
-We recommend using a `feature-branch` workflow: each user works on their own **local** `feature-branch`, pushes final changes to a **remote** `feature-brnach`. From the remote branch they can submit a **pull request** to the main branch on GitHub.
+We recommend using a Feature Branch Workflow: each user works on their own **local** `feature` branch, pushes final changes to a **remote** `feature` branch. From the remote branch they can submit a **pull request** to the main branch on GitHub.
 
 ![](https://github.com/uwescience/DSSG2021-min-wage/blob/main/img/feature-workflow-external.png)
 
@@ -18,7 +18,7 @@ git commit -m "adding filename"
 git add filename
 git commit -m "updating the filename"
 git pull origin main
-git push origin feature-branch
+git push origin feature
 
 ```
 


### PR DESCRIPTION
This simply syncs branch name in text and in the picture (`feature-branch` vs `feature`) as it might confuse newcomers to git.